### PR TITLE
Upgrade and cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,15 @@ FROM java:8u45-jre
 ENV DEBIAN_FRONTEND noninteractive
 
 # Locales
-RUN (echo 'en_US.UTF-8 UTF-8\nen_US ISO-8859-1' > /etc/locale.gen  \
-    && apt-get clean \
-    && apt-key update \
-	&& apt-get -q -y update --fix-missing \
-    && apt-get -q -y update \
-	&& apt-get install -q -y apt-utils \
-	&& apt-get install -q -y locales)
-
-RUN (locale-gen \
-	&& locale-gen en_US.UTF-8 \
-	&& dpkg-reconfigure locales)
+RUN echo 'en_US.UTF-8 UTF-8\nen_US ISO-8859-1' > /etc/locale.gen \
+    && apt-get -q -y update --fix-missing \
+    && apt-get install -q -y apt-utils locales \
+    && dpkg-reconfigure locales \
+    && apt-get -y purge apt-utils locales \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV LANGUAGE en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 ENV LC_CTYPE en_US.UTF-8
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8u45-jre
+FROM java:8u72-jre
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
This removes unnecessary command from Dockerfile and cleanup. This reduces the imagesize from `516.2 MB` to `313 MB`. It also upgrade to latest java version.
